### PR TITLE
Nhibernate 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -99,6 +99,7 @@ ClientBin
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
+.vs
 Generated_Code #added for RIA/Silverlight projects
 
 # Backup & report files from converting an old project file to a newer

--- a/NHibernate.Caches.Elasticache/ElasticacheClient.cs
+++ b/NHibernate.Caches.Elasticache/ElasticacheClient.cs
@@ -6,6 +6,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NHibernate.Caches.Elasticache
 {
@@ -157,6 +159,42 @@ namespace NHibernate.Caches.Elasticache
             // do nothing
         }
 
+        public Task<object> GetAsync(object key, CancellationToken cancellationToken)
+        {
+            var result = Get(key);
+            return Task.FromResult(result);
+        }
+
+        public Task PutAsync(object key, object value, CancellationToken cancellationToken)
+        {
+            Put(key, value);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(object key, CancellationToken cancellationToken)
+        {
+            Remove(key);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken)
+        {
+            Clear();
+            return Task.CompletedTask;
+        }
+
+        public Task LockAsync(object key, CancellationToken cancellationToken)
+        {
+            Lock(key);
+            return Task.CompletedTask;
+        }
+
+        public Task UnlockAsync(object key, CancellationToken cancellationToken)
+        {
+            Unlock(key);
+            return Task.CompletedTask;
+        }
+
         public long NextTimestamp()
         {
             return Timestamper.Next();
@@ -216,7 +254,7 @@ namespace NHibernate.Caches.Elasticache
         }
 
         /// <summary>
-        /// Compute an alternate key hash; used as a check that the looked-up value is 
+        /// Compute an alternate key hash; used as a check that the looked-up value is
         /// in fact what has been put there in the first place.
         /// </summary>
         /// <param name="key"></param>

--- a/NHibernate.Caches.Elasticache/ElasticacheClient.cs
+++ b/NHibernate.Caches.Elasticache/ElasticacheClient.cs
@@ -161,36 +161,59 @@ namespace NHibernate.Caches.Elasticache
 
         public Task<object> GetAsync(object key, CancellationToken cancellationToken)
         {
-            var result = Get(key);
-            return Task.FromResult(result);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<object>(cancellationToken);
+            }
+            return Task.FromResult(Get(key));
         }
 
         public Task PutAsync(object key, object value, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
             Put(key, value);
             return Task.CompletedTask;
         }
 
         public Task RemoveAsync(object key, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
             Remove(key);
             return Task.CompletedTask;
         }
 
         public Task ClearAsync(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
             Clear();
             return Task.CompletedTask;
         }
 
         public Task LockAsync(object key, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
             Lock(key);
             return Task.CompletedTask;
         }
 
         public Task UnlockAsync(object key, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
             Unlock(key);
             return Task.CompletedTask;
         }

--- a/NHibernate.Caches.Elasticache/NHibernate.Caches.Elasticache.csproj
+++ b/NHibernate.Caches.Elasticache/NHibernate.Caches.Elasticache.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHibernate.Caches.Elasticache</RootNamespace>
     <AssemblyName>NHibernate.Caches.Elasticache</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\blackbird\DefaultCollection\APINova\DotstoreAPI\</SolutionDir>
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -32,29 +33,34 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>false</DebugSymbols>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Amazon.ElastiCacheCluster, Version=1.0.0.4, Culture=neutral, PublicKeyToken=445456c82d5a0fce, processorArchitecture=MSIL">
-      <HintPath>..\packages\Amazon.ElastiCacheCluster.1.0.0.4\lib\net35\Amazon.ElastiCacheCluster.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Amazon.ElastiCacheCluster, Version=1.0.1.0, Culture=neutral, PublicKeyToken=445456c82d5a0fce, processorArchitecture=MSIL">
+      <HintPath>..\packages\Amazon.ElastiCacheCluster.1.0.1.0\lib\net35\Amazon.ElastiCacheCluster.dll</HintPath>
     </Reference>
-    <Reference Include="Enyim.Caching, Version=2.13.0.0, Culture=neutral, PublicKeyToken=cec98615db04012e, processorArchitecture=MSIL">
-      <HintPath>..\packages\EnyimMemcached.2.13\lib\net35\Enyim.Caching.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Enyim.Caching, Version=2.16.0.0, Culture=neutral, PublicKeyToken=cec98615db04012e, processorArchitecture=MSIL">
+      <HintPath>..\packages\EnyimMemcached.2.16.0\lib\net35\Enyim.Caching.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.0.0\lib\net461\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/NHibernate.Caches.Elasticache/app.config
+++ b/NHibernate.Caches.Elasticache/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Enyim.Caching" publicKeyToken="cec98615db04012e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.13.0.0" newVersion="2.13.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.16.0.0" newVersion="2.16.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -17,4 +17,7 @@ that is bundled with the nuget package under the tools folder.
 		<add key="AWSProfileName" value="" />
 -->
   </appSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
 </configuration>

--- a/NHibernate.Caches.Elasticache/packages.config
+++ b/NHibernate.Caches.Elasticache/packages.config
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Amazon.ElastiCacheCluster" version="1.0.0.4" targetFramework="net40" />
-  <package id="EnyimMemcached" version="2.13" targetFramework="net40" />
-  <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net40" />
-  <package id="NHibernate" version="4.0.4.4000" targetFramework="net40" />
+  <package id="Amazon.ElastiCacheCluster" version="1.0.1.0" targetFramework="net461" />
+  <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
+  <package id="EnyimMemcached" version="2.16.0" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="NHibernate" version="5.0.0" targetFramework="net461" />
+  <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
+  <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
 </packages>

--- a/nuget.nuspec
+++ b/nuget.nuspec
@@ -15,6 +15,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="NHibernate.Caches.Elasticache\bin\Release\NHibernate.Caches.Elasticache.dll" target="lib\NHibernate.Caches.Elasticache.dll" />
+    <file src="NHibernate.Caches.Elasticache\bin\Release\NHibernate.Caches.Elasticache.dll" target="lib\net461" />
   </files>
 </package>

--- a/nuget.nuspec
+++ b/nuget.nuspec
@@ -2,16 +2,16 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>NHibernate.Caches.Elasticache</id>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <authors>hcampos</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Cache provider for NHibernate using Enyim Memcached client and AmazonElastiCacheClusterConfig</description>
     <projectUrl>https://github.com/henriquecampos/NHibernate.Caches.Elasticache</projectUrl>
     <dependencies>
-      <dependency id="Amazon.ElastiCacheCluster" version="1.0.0.4" />
-      <dependency id="EnyimMemcached" version="2.13" />
-      <dependency id="Iesi.Collections" version="4.0.1.4000" />
-      <dependency id="NHibernate" version="4.0.4.4000" />
+      <dependency id="Amazon.ElastiCacheCluster" version="1.0.1.0" />
+      <dependency id="EnyimMemcached" version="2.16.0" />
+      <dependency id="Iesi.Collections" version="4.0.2" />
+      <dependency id="NHibernate" version="5.0.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Updates for use with Nhibernate 5: update to framework v 4.6.1 and update dependencies to latest versions. Changes for interface difference in Nhibernate 5.